### PR TITLE
Fixes #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ In the first case you get a warning if a file was already uploaded, in the secon
 
 **Downloading MMIF files**
 
-This uses the `storeapi/download` route. There are three modes. In the zero-guid mode you just hand in a pipeline specification and the server returns the server path and all files at that path:
+This uses the `storeapi/download` route. There are three modes. In the zero-GUID mode you just hand in a pipeline specification and the server returns the server path and all files at that path:
 
 ```bash
 curl -X POST 127.0.0.1:8001/storeapi/download \
@@ -70,7 +70,7 @@ curl -X POST 127.0.0.1:8001/storeapi/download \
 }
 ```
 
-If you add a guid then the server will return a MMIF file or a warning if the file did not exist:
+If you add a GUID, then the server will return a MMIF file or a warning if the file did not exist:
 
 ```bash
 curl -X POST 127.0.0.1:8001/storeapi/download
@@ -87,25 +87,25 @@ curl -X POST 127.0.0.1:8001/storeapi/download
 }
 ```
 
-With a list of guids you get a dictionary:
+With a list of GUIDs, the server will return a ZIP file. The `--output` ZIP file name must be specified in the request
+to the server. If any given GUIDs are not found, they will be listed in an `ERROR_LOG.json` file in the returned ZIP file.
 
 ```bash
 curl -X POST 127.0.0.1:8001/storeapi/download \
-    -H 'Content-Type: "application/json"' \
+    -H 'Content-Type: "application/zip"' \
     -d '
     {
-        "pipeline": { "swt-detection/v2.0-38-g7838415": {"pretty": "True"} },
-        "guid": ["cpb-aacip-690722078b2", "NO-SUCH-GUID"]
-    }'
+        "pipeline": { "whisper-wrapper/v3": {"modelSize": "tiny"} },
+        "guid": ["cpb-aacip-507-154dn40c26", "cpb-aacip-507-v40js9j432", "NO-SUCH-GUID"]
+    }' \
+    --output mmif_zip.zip
 ```
 ```json
 {
   "NO-SUCH-GUID": {
-    "error": "Did not find: NONE"
-  },
-  "cpb-aacip-690722078b2": {
-  	...
+    "Error": "Did not find NO-SUCH-GUID"
   }
+}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,7 @@ curl -X POST 127.0.0.1:8001/storeapi/download
 }
 ```
 
-With a list of GUIDs, the server will return a ZIP file. The `--output` ZIP file name must be specified in the request
-to the server. If any given GUIDs are not found, they will be listed in an `ERROR_LOG.json` file in the returned ZIP file.
+With a list of GUIDs, the server will return a ZIP file. The `--output` ZIP file name must be specified in the request to the server.
 
 ```bash
 curl -X POST 127.0.0.1:8001/storeapi/download \
@@ -100,13 +99,8 @@ curl -X POST 127.0.0.1:8001/storeapi/download \
     }' \
     --output mmif_zip.zip
 ```
-```json
-{
-  "NO-SUCH-GUID": {
-    "Error": "Did not find NO-SUCH-GUID"
-  }
-}
-```
+
+The zipfile returned has the MMIF files for each GUID, in addition it has an error log with notifications on which files could not be retrieved and a file with the pipeline path from the server.
 
 
 **MMIF storage analytics**

--- a/api/mmif_storage.py
+++ b/api/mmif_storage.py
@@ -242,18 +242,20 @@ def multi_guid_download_response(pipeline: str, guids: list, num_views: int):
     When retrieving multiple MMIFs for a pipeline, we construct a json object to
     store each guid as a key and each MMIF as the value.
     """
-    # mmifs_by_guid = dict()
+    errors = dict()
     mem_file = io.BytesIO()
     with zf.ZipFile(mem_file, 'w', ZIP_DEFLATED) as mmif_zip:
         for guid in guids:
             try:
                 # mmif = get_mmif_for_guid(pipeline, guid, num_views)
-                guid = guid + ".mmif"
-                path = os.path.join(pipeline, guid)
-                mmif_zip.write(filename=path, arcname=guid)
-            except StorageServerError as e:
-                pass
-            #     mmifs_by_guid[guid] = {"error": str(e)}
+                mmif_name = guid + ".mmif" # instead of using get_mmif_for_guid and needing to re-dump mmif
+                path = os.path.join(pipeline, mmif_name)
+                mmif_zip.write(filename=path, arcname=mmif_name)
+            except FileNotFoundError:
+                errors[guid] = {"Error": f"Did not find {guid}"}
+        if errors:
+            error_dump = json.dumps(errors, indent=2)
+            mmif_zip.writestr(zinfo_or_arcname="ERROR_LOG.json", data=error_dump)
     mem_file.seek(0)
     # user will need to add '--output <FILE>' arg to curl request
     return send_file(mem_file, mimetype='zip', as_attachment=True, download_name='test_zip.zip')

--- a/api/mmif_storage.py
+++ b/api/mmif_storage.py
@@ -248,17 +248,23 @@ def multi_guid_download_response(pipeline: str, guids: list, num_views: int):
         for guid in guids:
             try:
                 # mmif = get_mmif_for_guid(pipeline, guid, num_views)
-                mmif_name = guid + ".mmif" # instead of using get_mmif_for_guid and needing to re-dump mmif
+                # instead of using get_mmif_for_guid and needing to re-dump mmif
+                mmif_name = guid + ".mmif"
                 path = os.path.join(pipeline, mmif_name)
-                mmif_zip.write(filename=path, arcname=mmif_name)
+                mmif_zip.write(filename=path, arcname=f'multi-guid-response/files/{mmif_name}')
             except FileNotFoundError:
                 errors[guid] = {"Error": f"Did not find {guid}"}
-        if errors:
-            error_dump = json.dumps(errors, indent=2)
-            mmif_zip.writestr(zinfo_or_arcname="ERROR_LOG.json", data=error_dump)
+        mmif_zip.writestr(zinfo_or_arcname="multi-guid-response/pipeline_path.txt", data=pipeline)
+        error_dump = json.dumps(errors, indent=2)
+        mmif_zip.writestr(zinfo_or_arcname="multi-guid-response/errors.json", data=error_dump)
     mem_file.seek(0)
-    # user will need to add '--output <FILE>' arg to curl request
-    return send_file(mem_file, mimetype='zip', as_attachment=True, download_name='test_zip.zip')
+    # User will need to add '--output <FILE>' arg to curl request
+    # NOTE (mv 12/12/25), the --output is needed even with the use of download_name
+    # below. In fact, it still works for me withoutremove that parameter, but keeping
+    # it anyway.
+    return send_file(
+        mem_file, mimetype='zip', as_attachment=True,
+        download_name='multi-guid-response.zip')
 
 
 def get_mmif_for_guid(pipeline: str, guid: str, num_views: int):

--- a/api/mmif_storage.py
+++ b/api/mmif_storage.py
@@ -2,11 +2,15 @@ import hashlib
 import json
 import re
 import os
+import io
+import logging
+import zipfile as zf
 from pathlib import Path
+from zipfile import ZIP_DEFLATED
 
 from mmif import utils
 from clams_utils.aapb import guidhandler
-from flask import request, jsonify, Blueprint, current_app
+from flask import request, jsonify, Blueprint, current_app, send_file
 from mmif import Mmif
 
 from api import STORAGE_DIRECTORY
@@ -238,15 +242,21 @@ def multi_guid_download_response(pipeline: str, guids: list, num_views: int):
     When retrieving multiple MMIFs for a pipeline, we construct a json object to
     store each guid as a key and each MMIF as the value.
     """
-    mmifs_by_guid = dict()
-    for guid in guids:
-        response = single_guid_download_response(pipeline, guid, num_views)
-        try:
-            mmif = get_mmif_for_guid(pipeline, guid, num_views)
-            mmifs_by_guid[guid] = mmif
-        except StorageServerError as e:
-            mmifs_by_guid[guid] = {"error": str(e)}
-    return mmifs_by_guid
+    # mmifs_by_guid = dict()
+    mem_file = io.BytesIO()
+    with zf.ZipFile(mem_file, 'w', ZIP_DEFLATED) as mmif_zip:
+        for guid in guids:
+            try:
+                # mmif = get_mmif_for_guid(pipeline, guid, num_views)
+                guid = guid + ".mmif"
+                path = os.path.join(pipeline, guid)
+                mmif_zip.write(filename=path, arcname=guid)
+            except StorageServerError as e:
+                pass
+            #     mmifs_by_guid[guid] = {"error": str(e)}
+    mem_file.seek(0)
+    # user will need to add '--output <FILE>' arg to curl request
+    return send_file(mem_file, mimetype='zip', as_attachment=True, download_name='test_zip.zip')
 
 
 def get_mmif_for_guid(pipeline: str, guid: str, num_views: int):


### PR DESCRIPTION
Multi-GUID requests now return a ZIP file (as specified by the --output argument in the user's request) with the requested MMIF files and an error log containing information on any GUIDs not found on the server.
